### PR TITLE
fix: requirements.txt correct formatting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-spotipy=2.4.4
+spotipy==2.4.4


### PR DESCRIPTION
``` pip install -r requirements.txt ``` wont work if only one ```=``` is given in ```spotipy=2.4.4```
It would need to look like this ```spotipy==2.4.4```